### PR TITLE
Enable IR optimizer for mainnet deployment compliance

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ script = "scripts"
 solc = "0.8.19"
 optimizer = true
 optimizer_runs = 200
-via_ir = false
+via_ir = true
 evm_version = "paris"
 gas_reports = ["SoulBoundToken", "DepositPool", "ClaimPool", "SoulBoundDeployer"]
 


### PR DESCRIPTION
SoulBoundDeployer embeds creation bytecode of all three child contracts (SBT + DepositPool + ClaimPool) for single-transaction atomic deployment. Without IR optimization the deployer exceeds the EIP-170 contract size limit (25,861 > 24,576 bytes) and cannot deploy on mainnet or testnets.

via_ir = true reduces SoulBoundDeployer from 25,861 to 20,668 bytes (20% reduction, 3,908 bytes headroom). All contracts are now within mainnet limits.

foundry.toml: via_ir = false → via_ir = true