### PR TITLE
Fix: Enforce canonical on-chain identity derivation in mintSBT

### DIFF
--- a/docs/PROTOCOL_SPEC.md
+++ b/docs/PROTOCOL_SPEC.md
@@ -44,9 +44,10 @@ Non-transferable identity token. One per address. Cannot be burned or transferre
 ### Mint Flow
 
 1. Controller sets `currentEulaHash` on the contract.
-2. User calls `mintSBT(encryptedAccountId, zkpCommitment, eulaHash)`.
-3. Contract verifies: no existing SBT for caller, valid account ID, EULA hash matches current.
-4. SBT is created. The transaction signature constitutes cryptographic EULA acceptance.
+2. User calls `mintSBT(zkpCommitment, eulaHash)`.
+3. Contract verifies: no existing SBT for caller, EULA hash matches current.
+4. Contract internally derives `encryptedAccountId` deterministically from `msg.sender` and `chainId` to enforce canonical identity derivation.
+5. SBT is created. The transaction signature constitutes cryptographic EULA acceptance.
 
 ### ZKP Commitment
 

--- a/src/SoulBoundToken.sol
+++ b/src/SoulBoundToken.sol
@@ -92,21 +92,22 @@ contract SoulBoundToken is ISoulBoundToken {
 
     /**
      * @notice Mint SBT with EULA acceptance gate
-     * @param _encryptedAccountId Hashed account identifier
      * @param _zkpCommitment Privado ID ZKP commitment (can be bytes32(0) if not yet verified)
      * @param _eulaHash Must match currentEulaHash — the transaction signature IS the acceptance
+     * @dev _encryptedAccountId is the canonical identity derivation on-chain
      * @dev The act of calling this function with the correct EULA hash, signed by the user's
      *      wallet, constitutes cryptographic proof of EULA acceptance on an immutable ledger.
      */
     function mintSBT(
-        bytes32 _encryptedAccountId,
         bytes32 _zkpCommitment,
         bytes32 _eulaHash
     ) external {
         if (_sbtRegistry[msg.sender].exists) revert SBTAlreadyExists();
-        if (_encryptedAccountId == bytes32(0)) revert InvalidAccountId();
         if (currentEulaHash == bytes32(0)) revert EulaNotSet();
         if (_eulaHash != currentEulaHash) revert EulaMismatch();
+
+        bytes32 _encryptedAccountId = keccak256(abi.encodePacked(msg.sender, "SBF_ALPHA_V1", block.chainid));
+        
 
         _sbtRegistry[msg.sender] = SBTData({
             encryptedAccountId: _encryptedAccountId,


### PR DESCRIPTION
## Summary
This PR implements the mitigation for the Canonical Identity Derivation.

## Changes Made
* **`SoulBoundToken.sol`:** 
    * Removed `_encryptedAccountId` from the `mintSBT` parameter list to prevent arbitrary identifier injection.
    * Enforced on-chain deterministic derivation of the `encryptedAccountId` using `msg.sender`, `SBF_ALPHA_V1` and `block.chainid`.
* **`PROTOCOL_SPEC.md`:** Updated the Mint Flow documentation to reflect the new internal derivation step.
